### PR TITLE
Use config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ api-event.json
 aws_lambda/sivnorm
 swagger.json
 artifacts
+config.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,21 @@
 #######################
 FROM python:3.7 as dev
 
+ARG APP_PATH
 ARG APP_PORT
 
-WORKDIR /app
+WORKDIR /${APP_PATH}
 
-COPY requirements.txt /app
-COPY setup.py /app
-COPY sivnorm /app/sivnorm
-COPY aws_lambda /app/aws_lambda
-COPY tests /app/tests
-COPY docs /app/docs
-COPY dss /app/dss
+COPY LICENSE.md ./
+COPY README.md ./
+COPY requirements.txt ./
+COPY setup.py ./
+
+VOLUME /${APP_PATH}/sivnorm
+VOLUME /${APP_PATH}/aws_lambda
+VOLUME /${APP_PATH}/tests
+VOLUME /${APP_PATH}/dss
+VOLUME /${APP_PATH}/docs
 
 RUN pip install --no-cache-dir -r requirements.txt
 
@@ -25,6 +29,21 @@ LABEL traefik.http.routers.sivnorm.entrypoints="http"
 LABEL traefik.http.routers.sivnorm.rule="PathPrefix(`/sivnorm`) || PathPrefix(`/swaggerui`)"
 LABEL traefik.http.services.sivnorm.loadbalancer.server.port=${APP_PORT}
 
+CMD ["python","sivnorm/app.py"]
+
 ################################
 # Step 2: "production" target #
 ################################
+FROM dev as prod
+
+ADD aws_lambda ./aws_lambda
+ADD docs ./docs
+ADD dss ./dss
+ADD sivnorm ./sivnorm
+ADD tests ./tests
+COPY LICENSE.md ./
+COPY README.md ./
+COPY requirements.txt ./
+COPY setup.py ./
+
+CMD ["python","sivnorm/app.py"]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ export BASE_MODEL_PATH=/${APP}/dss
 # this is usefull with most python apps in dev mode because if stdout is
 # buffered logs do not shows in realtime
 export PYTHONUNBUFFERED=1
+export PYTHONDONTWRITEBYTECODE=1
 
 dummy               := $(shell touch artifacts)
 include ./artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 export no_proxy
 export http_proxy
-export EXEC_ENV=dev
-export PROJECT_NAME=sivnorm
+export PROJECT_NAME=iaflash
+export APP = sivnorm
 export APP_PATH := $(shell pwd)
 export APP_PORT=5000
 export APP_VERSION	:= $(shell git rev-parse HEAD | cut -c1-8)
 # For local dev: BASE_MODEL_PATH=/app/dss
 # For AWS lambda: BASE_MODEL_PATH=/tmp
-export BASE_MODEL_PATH=/app/dss
+export BASE_MODEL_PATH=/${APP}/dss
 # this is usefull with most python apps in dev mode because if stdout is
 # buffered logs do not shows in realtime
 export PYTHONUNBUFFERED=1
@@ -25,13 +25,13 @@ dss:
 	aws s3 cp s3://dss ./dss --recursive 
 
 dev: network dss
-	$(COMPOSE) up
+	export EXEC_ENV=dev; $(COMPOSE) -f docker-compose-dev.yml up --build 
 
 build: dss
-	$(COMPOSE) build
+	export EXEC_ENV=prod; $(COMPOSE) build
 
 up: network dss
-	$(COMPOSE) up -d
+	export EXEC_ENV=prod; $(COMPOSE) up -d
 
 stop:
 	$(COMPOSE) stop
@@ -47,7 +47,7 @@ nohup:
 
 docs/html:
 	$(COMPOSE) exec sivnorme python sivnorm/export_swagger.py
-	$(COMPOSE) exec sivnorme make -C /app/docs html
+	$(COMPOSE) exec sivnorme make -C /${APP}/docs html
 
 docs: docs/html
 	echo "Docs"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,18 @@
+version: '2.3'
+services:
+   sivnorme:
+    image: ${PROJECT_NAME}-${APP}-${EXEC_ENV}:${APP_VERSION}
+    container_name: ${PROJECT_NAME}-${APP}-${EXEC_ENV}
+    ports:
+     - ${APP_PORT}:${APP_PORT}
+    volumes:
+      - ./aws_lambda:/${APP}/aws_lambda/
+      - ./docs:/${APP}/docs/
+      - ./dss:/${APP}/dss/
+      - ./sivnorm:/${APP}/sivnorm/
+      - ./tests:/${APP}/tests/
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.sivnorm.entrypoints=http
+      - traefik.http.routers.sivnorm.rule=PathPrefix(`/sivnorm`) || PathPrefix(`/swaggerui`)
+      - traefik.http.services.sivnorm.loadbalancer.server.port=5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2.3'
 services:
    sivnorme:
-    image: ${PROJECT_NAME}-sivnorm-${EXEC_ENV}:${APP_VERSION}
-    container_name: ${PROJECT_NAME}-sivnorm-${EXEC_ENV}
+    image: ${PROJECT_NAME}-${APP}:${APP_VERSION}
+    container_name: ${PROJECT_NAME}-${APP}
     build:
       context: .
       target: ${EXEC_ENV}
@@ -11,6 +11,7 @@ services:
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
         APP_PORT: ${APP_PORT}
+        APP_PATH: /${APP}
     environment:
      - http_proxy=${http_proxy}
      - https_proxy=${http_proxy}
@@ -18,17 +19,9 @@ services:
      - BASE_MODEL_PATH=${BASE_MODEL_PATH}
      - APP_PORT=${APP_PORT}
     ports:
-     - ${APP_PORT}:${APP_PORT}
+    - ${APP_PORT}:${APP_PORT}
     networks:
      - isolated_nw
-    volumes:
-      - ./:/app
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.sivnorm.entrypoints=http
-      - traefik.http.routers.sivnorm.rule=PathPrefix(`/sivnorm`) || PathPrefix(`/swaggerui`)
-      - traefik.http.services.sivnorm.loadbalancer.server.port=5000
-    command: "python sivnorm/app.py"
 
 networks:
   isolated_nw:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
      - no_proxy=${no_proxy}
      - BASE_MODEL_PATH=${BASE_MODEL_PATH}
      - APP_PORT=${APP_PORT}
+     - PYTHONUNBUFFERED=${PYTHONUNBUFFERED}
+     - PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
     ports:
     - ${APP_PORT}:${APP_PORT}
     networks:

--- a/sivnorm/process.py
+++ b/sivnorm/process.py
@@ -7,7 +7,13 @@ import pandas as pd
 from multiprocessing import Pool
 from functools import partial
 
-dst_path = os.environ['BASE_MODEL_PATH'] # locally
+if os.path.exists('./sivnorm/config.ini'):
+    import configparser
+    config = configparser.ConfigParser()
+    config.read('./sivnorm/config.ini')
+    dst_path = config.get('config','BASE_MODEL_PATH')
+else:
+    dst_path = os.environ['BASE_MODEL_PATH']
 
 ref_marque_modele_path = dict(
         siv=osp.join(dst_path, 'esiv_marque_modele_genre.csv'),


### PR DESCRIPTION
If a config file exists in `sivnorm/config.ini` then it is used to configure BASE_MODEL_PATH variable.

Fixes #9 

The contents of the file should be like:

```ini
# sivnorm/config.ini
[config]
BASE_MODEL_PATH = /sivnorm/dss
```